### PR TITLE
Fix d'un problème de mention sur téléphone

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -191,7 +191,7 @@ module.exports = {
 
         }
 
-        const mentionRegex = RegExp(`^<@!${client.user.id}>$`);
+        const mentionRegex = RegExp(`^<@!?${client.user.id}>$`);
         if (message.content.match(mentionRegex)) {
 
 


### PR DESCRIPTION
Lorsque l'ont mentionne avec le @mention ou le <@id>, le rendu en fond rajoute un point d'exclamation sur PC alors qu'il ne le rajoute pas sur téléphone. C'est pour cette raison qu'il faut rajouter le point d'interrogation dans la regex pour rendre le point d'exclamation optionel